### PR TITLE
Redirect output to /dev/null

### DIFF
--- a/RP - restart-emulationsation-from-ssh.sh
+++ b/RP - restart-emulationsation-from-ssh.sh
@@ -1,4 +1,4 @@
 !/bin/bash
 
 export DISPLAY=:0
-nohup emulationstation &
+nohup emulationstation >/dev/null 2>&1 & 


### PR DESCRIPTION
When you run a command with nohup (meaning "no hangup") you get a file in your current working directory containing any output that would have went to the terminal but is instead directed to this file since the process is running headless.  The change I added instead redirects that output to /dev/null and avoids creating a nohup.out file in the current directory.