### PR TITLE
Remove need to press enter.

### DIFF
--- a/RP - restart-emulationstation-from-ssh.sh
+++ b/RP - restart-emulationstation-from-ssh.sh
@@ -1,4 +1,4 @@
-!/bin/bash
+#!/usr/bin/env bash
 
 export DISPLAY=:0
-nohup emulationstation &
+(nohup emulationstation 2> /dev/null &)


### PR DESCRIPTION
Fixing the shebang line and altering the nohup command to remove the need to press enter after running the script. Running it now returns the user to a command prompt properly.